### PR TITLE
Add example for backtracking when a blur event sets a className bound property

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ So far it includes:
  * [Modifying an already rendered property in a component lifecycle hook](https://github.com/GavinJoyce/backtracking/pull/1)
  * [Calling a `set` within a `get`](https://github.com/GavinJoyce/backtracking/pull/5)
  * [Emitting an action on component init](https://github.com/GavinJoyce/backtracking/pull/6)
+ * [Setting a className bound property through blur events](https://github.com/GavinJoyce/backtracking/pull/13)
 
 I'll add more cases as I come across them in my own app. Please send a PR if you have additional cases.
 

--- a/app/components/component-that-updates-props-through-blur-events.js
+++ b/app/components/component-that-updates-props-through-blur-events.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNameBindings: ['propSetOnBlur'],
+  propSetOnChange: false,
+  propSetOnBlur: false,
+  actions: {
+    toggleProp() {
+      this.toggleProperty('propSetOnChange');
+    },
+  },
+});

--- a/app/router.js
+++ b/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
   this.route('example3');
   this.route('example4');
   this.route('example5');
+  this.route('example6');
 });
 
 export default Router;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -5,6 +5,7 @@
 [{{#link-to 'example3'}}Example 3{{/link-to}}]
 [{{#link-to 'example4'}}Example 4{{/link-to}}]
 [{{#link-to 'example5'}}Example 5{{/link-to}}]
+[{{#link-to 'example6'}}Example 6{{/link-to}}]
 
 <hr />
 

--- a/app/templates/components/component-that-updates-props-through-blur-events.hbs
+++ b/app/templates/components/component-that-updates-props-through-blur-events.hbs
@@ -1,0 +1,9 @@
+<label for="backtracking-checkbox">
+  Tick the box to trigger the backtracking re-render error
+</label>
+<input
+ id="backtracking-checkbox"
+ type="checkbox"
+ disabled={{propSetOnChange}}
+ onblur={{action (mut propSetOnBlur) true}}
+ onchange={{action "toggleProp"}}/>

--- a/app/templates/example6.hbs
+++ b/app/templates/example6.hbs
@@ -1,0 +1,15 @@
+<div class="explain">
+  <p>
+    You'll see
+    "Assertion Failed: You modified "propSetOnBlur" twice on &lt;backtracking@component:component-that-updates-props-through-blur-events::ember411&rt; in a single render.
+    It was rendered in "component:component-that-updates-props-through-blur-events" and modified in "component:component-that-updates-props-through-blur-events".
+    This was unreliable and slow in Ember 1.x and is no longer supported.
+    See https://github.com/emberjs/ember.js/issues/13948 for more details."
+    in the console.
+  </p>
+
+  <p>
+    To avoid this error, don't update properties of classNameBindings through blur events
+  </p>
+</div>
+{{component-that-updates-props-through-blur-events}}


### PR DESCRIPTION
In this example backtracking re-rendering seems to occur once a property is set on an input element whose `disabled` state is mutated which in turn triggers a `blur` event. 

If this `blur` event happens to mutate a property that is bound through `classNameBindings` the assertion will be thrown.

![blurry](https://user-images.githubusercontent.com/8811742/38895997-d3f3f7be-4291-11e8-9748-34b1d569f8e9.gif)